### PR TITLE
Dev/set to production

### DIFF
--- a/CICD.Tools.DataMinerDeploy.LibTests/LocalDeploymentFactoryTests.cs
+++ b/CICD.Tools.DataMinerDeploy.LibTests/LocalDeploymentFactoryTests.cs
@@ -75,7 +75,6 @@
             Mock<IFileIO> fakeFile = new Mock<IFileIO>();
             fs.Setup(p => p.File).Returns(fakeFile.Object);
 
-
             string pathToArtifact = "fake/path/artifactname.dmapp";
             string dmServerLocation = "fake.host.server";
 
@@ -99,7 +98,6 @@
             Mock<IDataMinerService> fakeService = new Mock<IDataMinerService>();
 
             fs.Setup(p => p.File).Returns(fakeFile.Object);
-
 
             string pathToArtifact = "TestData/TestNewDmapp.dmapp";
             string dmServerLocation = "fake.host.server";
@@ -170,8 +168,8 @@
             result.Should().BeTrue();
             fakeService.Verify(p => p.TryConnect(dmServerLocation, user, password));
             fakeService.Verify(p => p.InstallNewStyleAppPackages(pathToArtifact));
-
         }
+
         [TestMethod]
         public async Task LocalTest_EnvEncrypedKey_OK()
         {

--- a/CICD.Tools.DataMinerDeploy.LibTests/LocalDeploymentFactoryTests.cs
+++ b/CICD.Tools.DataMinerDeploy.LibTests/LocalDeploymentFactoryTests.cs
@@ -250,7 +250,8 @@
             result.Should().BeTrue();
 
             fakeService.Verify(p => p.TryConnect(dmServerLocation, user, password));
-            fakeService.Verify(p => p.InstallDataMinerProtocol(pathToArtifact));
+            var setToProduction = (false, false);
+            fakeService.Verify(p => p.InstallDataMinerProtocol(pathToArtifact, setToProduction));
         }
     }
 }

--- a/CICD.Tools.DataMinerDeploy/PostActionsInputArgument.cs
+++ b/CICD.Tools.DataMinerDeploy/PostActionsInputArgument.cs
@@ -1,0 +1,9 @@
+﻿namespace Skyline.DataMiner.CICD.Tools.DataMinerDeploy
+{
+    internal enum PostActionsInputArgument
+    {
+        None,
+        SetToProduction,
+        SetToProductionIncludingTemplates
+    }
+}

--- a/CICD.Tools.DataMinerDeploy/Properties/launchSettings.json
+++ b/CICD.Tools.DataMinerDeploy/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "CICD.Tools.DataMinerDeploy": {
       "commandName": "Project",
-      "commandLineArgs": "from-artifact-with-post-actions \r\n--path-to-artifact \"C:\\Users\\JANS\\Downloads\\Meinberg_LANTIME_IMS-SCG_1_0_1_3.dmprotocol\"\r\n--dm-server-location \"dms-it-dev.skyline.local\"\r\n--set-to-production\r\n--copy-templates\r\n--debug\r\n\r\n"
+      "commandLineArgs": "from-artifact\r\n--path-to-artifact \"C:\\Users\\JANS\\Downloads\\Meinberg_LANTIME_IMS-SCG_1_0_1_3.dmprotocol\"\r\n--dm-server-location \"dms-it-dev.skyline.local\"\r\n--post-action SetToProduction\r\n--debug\r\n\r\n"
     }
   }
 }

--- a/CICD.Tools.DataMinerDeploy/Properties/launchSettings.json
+++ b/CICD.Tools.DataMinerDeploy/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "CICD.Tools.DataMinerDeploy": {
       "commandName": "Project",
-      "commandLineArgs": "from-artifact \r\n--path-to-artifact \"C:\\Users\\JANS\\Downloads\\Meinberg_LANTIME_IMS-SCG_1_0_1_3.dmprotocol\"\r\n--dm-server-location \"dms-it-dev.skyline.local\"\r\n--debug\r\n\r\n"
+      "commandLineArgs": "from-artifact-with-post-actions \r\n--path-to-artifact \"C:\\Users\\JANS\\Downloads\\Meinberg_LANTIME_IMS-SCG_1_0_1_3.dmprotocol\"\r\n--dm-server-location \"dms-it-dev.skyline.local\"\r\n--set-to-production\r\n--copy-templates\r\n--debug\r\n\r\n"
     }
   }
 }

--- a/CICD.Tools.DataminerDeploy/Program.cs
+++ b/CICD.Tools.DataminerDeploy/Program.cs
@@ -60,7 +60,7 @@
                 IsRequired = false,
             };
 
-            deployTimeout.SetDefaultValue(15);
+            deployTimeout.SetDefaultValue(900);
 
             var fromCatalog = new Command("from-catalog", "Deploys a specific package from the cloud to a cloud-connected DataMiner Agent. Currently only supports private artifacts uploaded using a key from the organization.")
             {

--- a/CICD.Tools.DataminerDeploy/README.md
+++ b/CICD.Tools.DataminerDeploy/README.md
@@ -151,3 +151,26 @@ WinEncryptedKeys --name "DATAMINER_DEPLOY_PASSWORD_ENCRYPTED" --value "MyPasswor
 
 You can review and make suggestions to the sourcecode of this encryption tool here: 
 https://github.com/SkylineCommunications/Skyline.DataMiner.CICD.Tools.WinEncryptedKeys
+
+### Post Actions
+
+It's possible to define a '--post-action' argument, this is an action to be executed after initial deployment.
+
+Currently the following options are possible:
+
+ - SetToProduction:
+
+
+This will only work for protocol packages (.dmprotocol). After deployment, it will set the deployed version as production.
+
+
+ - SetToProductionIncludingTemplates:
+
+This will only work for protocol packages (.dmprotocol). After deployment, it will set the deployed version as protocol and also copy over all provided templates into production.
+
+
+For example
+
+```console
+dataminer-package-deploy from-artifact --path-to-artifact "" --dm-server-location "" --post-action SetToProduction
+```

--- a/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/CatalogArtifact.cs
+++ b/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/CatalogArtifact.cs
@@ -52,6 +52,15 @@
         }
 
         /// <summary>
+        /// Adds a series of actions to attempt after deployment.
+        /// </summary>
+        /// <param name="postDeployActions">An instance of <see cref="PostDeployActions"/> indicating what actions to try performing after deployment.</param>
+        public void AddPostDeployActions(PostDeployActions postDeployActions)
+        {
+            throw new InvalidOperationException("There is currently no support for additional actions after deployment from the catalog. Such actions are only possible for direct deployment of protocol packages (.dmprotocol).");
+        }
+
+        /// <summary>
         /// Cancels an ongoing deployment. Create a new CatalogArtifact to attempt a new upload.
         /// </summary>
         public void CancelDeployment()

--- a/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/CatalogArtifact.cs
+++ b/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/CatalogArtifact.cs
@@ -11,10 +11,10 @@
 
     internal class CatalogArtifact : IArtifact
     {
-        private readonly ILogger logger;
         private readonly string artifactIdentifier;
         private readonly CancellationTokenSource cancellationTokenSource;
         private readonly string catalogAgentToken;
+        private readonly ILogger logger;
         private readonly ICatalogService service;
         private bool disposedValue;
         private string keyFromEnv;

--- a/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/IArtifact.cs
+++ b/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/IArtifact.cs
@@ -19,5 +19,11 @@
         /// </summary>
         /// <returns><c>true</c> if deployment was successful; otherwise, <c>false</c>.</returns>
         Task<bool> DeployAsync(TimeSpan timeout);
+
+        /// <summary>
+        /// Adds a series of actions to attempt after deployment.
+        /// </summary>
+        /// <param name="postDeployActions">An instance of <see cref="PostDeployActions"/> indicating what actions to try performing after deployment.</param>
+        void AddPostDeployActions(PostDeployActions postDeployActions);
     }
 }

--- a/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/IArtifact.cs
+++ b/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/IArtifact.cs
@@ -9,6 +9,12 @@
     public interface IArtifact : IDisposable
     {
         /// <summary>
+        /// Adds a series of actions to attempt after deployment.
+        /// </summary>
+        /// <param name="postDeployActions">An instance of <see cref="PostDeployActions"/> indicating what actions to try performing after deployment.</param>
+        void AddPostDeployActions(PostDeployActions postDeployActions);
+
+        /// <summary>
         /// Attempts to cancel an ongoing deployment. Create a new IArtifact to attempt a new deployment.
         /// </summary>
         /// <returns></returns>
@@ -19,11 +25,5 @@
         /// </summary>
         /// <returns><c>true</c> if deployment was successful; otherwise, <c>false</c>.</returns>
         Task<bool> DeployAsync(TimeSpan timeout);
-
-        /// <summary>
-        /// Adds a series of actions to attempt after deployment.
-        /// </summary>
-        /// <param name="postDeployActions">An instance of <see cref="PostDeployActions"/> indicating what actions to try performing after deployment.</param>
-        void AddPostDeployActions(PostDeployActions postDeployActions);
     }
 }

--- a/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/LocalArtifact.cs
+++ b/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/LocalArtifact.cs
@@ -16,18 +16,18 @@
 
     internal class LocalArtifact : IArtifact
     {
-        private readonly ILogger logger;
         private readonly string dataminerPassword;
         private readonly string dataMinerServerLocation;
         private readonly string dataminerUser;
         private readonly IFileSystem fs;
+        private readonly ILogger logger;
         private readonly string pathToArtifact;
         private readonly IDataMinerService service;
         private bool disposedValue;
-        private string pwFromEnv;
-        private string userFromEnv;
-        private bool shouldDisposeConnection = true;
         private PostDeployActions postDeployActions;
+        private string pwFromEnv;
+        private bool shouldDisposeConnection = true;
+        private string userFromEnv;
 
         public LocalArtifact(IDataMinerService dataMinerService, string pathToArtifact, string dataMinerServerLocation, string dataMinerUser, string dataMinerPassword, ILogger logger, IFileSystem fs)
         {
@@ -59,11 +59,6 @@
         {
         }
 
-        public void CancelDeployment()
-        {
-            throw new InvalidOperationException("Unable to cancel deployment of a local artifact.");
-        }
-
         /// <summary>
         /// Adds a series of actions to attempt after deployment.
         /// </summary>
@@ -71,6 +66,11 @@
         public void AddPostDeployActions(PostDeployActions postDeployActions)
         {
             this.postDeployActions = postDeployActions;
+        }
+
+        public void CancelDeployment()
+        {
+            throw new InvalidOperationException("Unable to cancel deployment of a local artifact.");
         }
 
         public async Task<bool> DeployAsync(TimeSpan timeout)
@@ -166,24 +166,6 @@
             }
         }
 
-        /// <summary>
-        ///  Attempts to find the necessary API key in Environment Variables. In order of priority:
-        ///  <para>- key stored as an Environment Variable called "dmcatalogtoken". (unix/win)</para>
-        ///  <para>- key configured using Skyline.DataMiner.CICD.Tools.WinEncryptedKeys called "dmcatalogtoken_encrypted" (windows only)</para>
-        /// </summary>
-        private void TryFindEnvironmentKeys()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // Order of priority. Priority for regular environment keys as they are win/unix and industry standard in pipelines
-                userFromEnv = TryFindEncryptedEnvironmentKey("DATAMINER_DEPLOY_USER_ENCRYPTED") ?? userFromEnv;
-                pwFromEnv = TryFindEncryptedEnvironmentKey("DATAMINER_DEPLOY_PASSWORD_ENCRYPTED") ?? pwFromEnv;
-
-                userFromEnv = TryFindEnvironmentKey("DATAMINER_DEPLOY_USER") ?? userFromEnv;
-                pwFromEnv = TryFindEnvironmentKey("DATAMINER_DEPLOY_PASSWORD") ?? pwFromEnv;
-            }
-        }
-
         private string TryFindEncryptedEnvironmentKey(string key)
         {
             try
@@ -227,6 +209,24 @@
             }
 
             return userFromEnvironment;
+        }
+
+        /// <summary>
+        ///  Attempts to find the necessary API key in Environment Variables. In order of priority:
+        ///  <para>- key stored as an Environment Variable called "dmcatalogtoken". (unix/win)</para>
+        ///  <para>- key configured using Skyline.DataMiner.CICD.Tools.WinEncryptedKeys called "dmcatalogtoken_encrypted" (windows only)</para>
+        /// </summary>
+        private void TryFindEnvironmentKeys()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Order of priority. Priority for regular environment keys as they are win/unix and industry standard in pipelines
+                userFromEnv = TryFindEncryptedEnvironmentKey("DATAMINER_DEPLOY_USER_ENCRYPTED") ?? userFromEnv;
+                pwFromEnv = TryFindEncryptedEnvironmentKey("DATAMINER_DEPLOY_PASSWORD_ENCRYPTED") ?? pwFromEnv;
+
+                userFromEnv = TryFindEnvironmentKey("DATAMINER_DEPLOY_USER") ?? userFromEnv;
+                pwFromEnv = TryFindEnvironmentKey("DATAMINER_DEPLOY_PASSWORD") ?? pwFromEnv;
+            }
         }
     }
 }

--- a/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/LocalArtifact.cs
+++ b/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/LocalArtifact.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
 
     using Microsoft.Extensions.Logging;
+
     using Newtonsoft.Json;
 
     using Skyline.DataMiner.CICD.FileSystem;
@@ -26,6 +27,7 @@
         private string pwFromEnv;
         private string userFromEnv;
         private bool shouldDisposeConnection = true;
+        private PostDeployActions postDeployActions;
 
         public LocalArtifact(IDataMinerService dataMinerService, string pathToArtifact, string dataMinerServerLocation, string dataMinerUser, string dataMinerPassword, ILogger logger, IFileSystem fs)
         {
@@ -60,6 +62,15 @@
         public void CancelDeployment()
         {
             throw new InvalidOperationException("Unable to cancel deployment of a local artifact.");
+        }
+
+        /// <summary>
+        /// Adds a series of actions to attempt after deployment.
+        /// </summary>
+        /// <param name="postDeployActions">An instance of <see cref="PostDeployActions"/> indicating what actions to try performing after deployment.</param>
+        public void AddPostDeployActions(PostDeployActions postDeployActions)
+        {
+            this.postDeployActions = postDeployActions;
         }
 
         public async Task<bool> DeployAsync(TimeSpan timeout)
@@ -117,7 +128,7 @@
 
                     case ArtifactTypeEnum.dmprotocol:
                         logger.LogDebug($"Found DataMiner protocol package (.dmprotocol).");
-                        service.InstallDataMinerProtocol(pathToArtifact);
+                        service.InstallDataMinerProtocol(pathToArtifact, postDeployActions?.SetToProduction ?? (false, false));
                         break;
 
                     default:

--- a/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/PostDeployActions.cs
+++ b/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerArtifacts/PostDeployActions.cs
@@ -1,0 +1,13 @@
+﻿namespace Skyline.DataMiner.CICD.Tools.DataMinerDeploy.Lib
+{
+    /// <summary>
+    /// A series of actions to perform after deployment and installation has happened.
+    /// </summary>
+    public class PostDeployActions
+    {
+        /// <summary>
+        /// Currently only works for local-artifact deployment directly to an agent and only for protocol packages (.dmprotocol).
+        /// </summary>
+        public (bool isTrue, bool copyTemplates) SetToProduction { get; set; }
+    }
+}

--- a/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerService/IDataMinerService.cs
+++ b/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerService/IDataMinerService.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Represents a service that can connect and perform installations to a DataMiner Agent.
     /// </summary>
-    public interface IDataMinerService: IDisposable
+    public interface IDataMinerService : IDisposable
     {
         /// <summary>
         /// Installs a DataMiner protocol (aka connector, driver) package (.dmprotocol). This call will wait on the installation to complete.
@@ -15,18 +15,18 @@
         void InstallDataMinerProtocol(string protocol, (bool isTrue, bool copyTemplates) setToProduction);
 
         /// <summary>
-        /// Install a DataMiner application package (.dmapp). This call will wait on the installation to complete.
-        /// </summary>
-        /// <param name="packageFilePath">The file path to the package.</param>
-        void InstallNewStyleAppPackages(string packageFilePath);
-
-        /// <summary>
         /// Install a legacy style application package (.dmapp when unzipped has an Upgrade.zip inside). This call will wait on the installation to complete.
         /// </summary>
         /// <remarks>Running this call will restart the DataMiner Agent.</remarks>
         /// <param name="package">The file path to the package.</param>
         /// <param name="timeout">A timeout time to wait on the installation and restart of the Agent.</param>
         void InstallLegacyStyleAppPackages(string package, TimeSpan timeout);
+
+        /// <summary>
+        /// Install a DataMiner application package (.dmapp). This call will wait on the installation to complete.
+        /// </summary>
+        /// <param name="packageFilePath">The file path to the package.</param>
+        void InstallNewStyleAppPackages(string packageFilePath);
 
         /// <summary>
         /// Try to connect to a DataMiner Agent using the host name or IP address. This should be called before attempting an installation.

--- a/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerService/IDataMinerService.cs
+++ b/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerService/IDataMinerService.cs
@@ -11,7 +11,8 @@
         /// Installs a DataMiner protocol (aka connector, driver) package (.dmprotocol). This call will wait on the installation to complete.
         /// </summary>
         /// <param name="protocol">The file path to the package.</param>
-        void InstallDataMinerProtocol(string protocol);
+        /// <param name="setToProduction">isTrue is set to <c>true</c> if the protocol should also be set to production; otherwise, <c>false</c>. copyTemplates is <c>true</c> if templates should be copied over; otherwise, <c>false</c>.</param>
+        void InstallDataMinerProtocol(string protocol, (bool isTrue, bool copyTemplates) setToProduction);
 
         /// <summary>
         /// Install a DataMiner application package (.dmapp). This call will wait on the installation to complete.

--- a/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerService/SLNetDataMinerService.cs
+++ b/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerService/SLNetDataMinerService.cs
@@ -20,6 +20,7 @@
     using Skyline.DataMiner.Net.AppPackages;
     using Skyline.DataMiner.Net.Exceptions;
     using Skyline.DataMiner.Net.Messages;
+    using Skyline.DataMiner.Net.Messages.Advanced;
     using Skyline.DataMiner.Net.Upgrade;
 
     internal class SLNetDataMinerService : IDataMinerService
@@ -43,7 +44,34 @@
             GC.SuppressFinalize(this);
         }
 
-        public void InstallDataMinerProtocol(string protocol)
+        /// <summary>
+        /// Allows you to place a protocol version as production version.
+        /// </summary>
+        /// <param name="protocolName">Name of protocol.</param>
+        /// <param name="protocolVersion">Version of protocol.</param>
+        /// <param name="copyTemplates">Indicates if templates should be included.</param>
+        private void SetAsProduction(string protocolName, string protocolVersion, bool copyTemplates)
+        {
+            var request = new SetDataMinerInfoMessage
+            {
+                ElementID = -1,
+                bInfo1 = int.MaxValue,
+                IInfo1 = int.MaxValue,
+                IInfo2 = int.MaxValue,
+                bInfo2 = copyTemplates ? 1 : 0,
+                What = (int)NotifyType.SetAsCurrentProtoocol,
+                Sa1 = new SA(new[] { protocolName, protocolVersion })
+            };
+
+            var resp = slnet.SendSingleResponseMessage(request) as SetDataMinerInfoResponseMessage;
+            var errorMessage = $"Could not set protocol {protocolName}/{protocolVersion} as production version.";
+            if (resp != null && resp.iRet == 0)
+                return;
+            string message = resp == null ? errorMessage + " The response was null." : errorMessage + $" The returned error code was {resp.iRet}";
+            throw new InvalidOperationException(message);
+        }
+
+        public void InstallDataMinerProtocol(string protocol, (bool isTrue, bool copyTemplates) setToProduction)
         {
             if (slnet == null)
             {
@@ -68,6 +96,15 @@
             {
                 UploadDataMinerProtocolMessage uploadDataMinerProtocolMessage = new UploadDataMinerProtocolMessage(dmprotocolCookie);
                 uploadDataMinerProtocolResponse = slnet.SendSingleResponseMessage(uploadDataMinerProtocolMessage) as UploadDataMinerProtocolResponse;
+
+                if (setToProduction.isTrue)
+                {
+                    logger.LogDebug($"Setting connector {uploadDataMinerProtocolResponse.ProtocolName} with version {uploadDataMinerProtocolResponse.ProtocolVersion} to production" + (setToProduction.copyTemplates ? " and copying over templates" : "") + "...");
+
+                    SetAsProduction(uploadDataMinerProtocolResponse.ProtocolName, uploadDataMinerProtocolResponse.ProtocolVersion, setToProduction.copyTemplates);
+
+                    logger.LogDebug($"Connector set to production.");
+                }
             }
             catch (Exception e)
             {
@@ -153,7 +190,7 @@
                     ip = ipAddress.ToString();
                 }
 
-                if(ip == "127.0.0.1")
+                if (ip == "127.0.0.1")
                 {
                     throw new InvalidOperationException("Unsupported: Legacy style local artifact deployment to localhost. As an alternative, please deploy from the catalog or deploy from a remote server.");
                 }

--- a/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerService/SLNetDataMinerService.cs
+++ b/Skyline.DataMiner.CICD.Tools.DataminerDeploy.Lib/DataMinerService/SLNetDataMinerService.cs
@@ -55,9 +55,9 @@
             var request = new SetDataMinerInfoMessage
             {
                 ElementID = -1,
-                bInfo1 = int.MaxValue,
-                IInfo1 = int.MaxValue,
-                IInfo2 = int.MaxValue,
+                bInfo1 = Int32.MaxValue,
+                IInfo1 = Int32.MaxValue,
+                IInfo2 = Int32.MaxValue,
                 bInfo2 = copyTemplates ? 1 : 0,
                 What = (int)NotifyType.SetAsCurrentProtoocol,
                 Sa1 = new SA(new[] { protocolName, protocolVersion })


### PR DESCRIPTION
Added the ability to specify a --post-action for deployment 'from-artifact'. In this case functionality was added to Set a protocol to production (and copy over templates or not) after deployment of a .dmprotocol.